### PR TITLE
Fixed registration form bug

### DIFF
--- a/ten_k_brews_app/static/css/sakura.css
+++ b/ten_k_brews_app/static/css/sakura.css
@@ -164,6 +164,6 @@ label, legend, fieldset {
   margin-bottom: .5rem;
   font-weight: 600; }
 
-.user-login-span {
-    text-align: right;
+.error {
+  color: red;
 }

--- a/ten_k_brews_app/templates/account_pages/register.html
+++ b/ten_k_brews_app/templates/account_pages/register.html
@@ -13,25 +13,16 @@
 
 <h2>Register</h2>
 
-<div class="message">
-  {% if message %}
-    <p>{{ message }}</p>
-  {% endif %}
-</div>
+{% for message in messages %}
+    <p><strong {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}:</strong></p>
+{% endfor %}
 
-{% if messages %}
-<ul class="messages">
-    {% for message in messages %}
-    <li {% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-    {% endfor %}
-</ul>
-{% endif %}
 
 <form method="POST" action="">
   {% csrf_token %}
   <table id="registration-form">
 
-    <!-- Displaying the form fields individually for more control over how the help_text is displayed -->
+<!-- Displaying the form fields individually for more control over how the help_text is displayed-->
 
     {% for field in registration_form %}
     <tr>
@@ -45,10 +36,6 @@
             {{ error }}
           </div>
         {% endfor %}
-
-        {% if field.help_text %}
-          <p>{{ field.help_text }}</p>
-        {% endif %}
       </td>
       {% endif %}
 

--- a/ten_k_brews_app/views/user_views.py
+++ b/ten_k_brews_app/views/user_views.py
@@ -58,9 +58,10 @@ def register(request):
                 messages.add_message(request, messages.ERROR, 'Unable to log in new user')
         else:
             messages.add_message(request, messages.INFO, 'Please check the data you entered')
+            print(registration_form)
             # include invalid form with error messages added to it. Error messages will be displayed by the template.
             return render(request, 'account_pages/register.html',
-                          {'form': registration_form, 'search_form': search_form})
+                          {'registration_form': registration_form, 'search_form': search_form})
 
     registration_form = UserRegistrationForm()
     return render(request, 'account_pages/register.html',


### PR DESCRIPTION
When an invalid form was submitted (usually mismatched passwords or an insufficiently complex password), the form wasn't being re-displayed along with the message indicating that the user should check the data they've entered.

The issue ended up being that the form was being sent to the renderer with the key 'form', when the template expected 'registration_form'. It's always something dumb.